### PR TITLE
feat: handle unknown host exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 
 ```xml
 <dependency>
-    <groupId>org.ministack</groupId>
-    <artifactId>testcontainers-ministack</artifactId>
-    <version>0.1.0</version>
-    <scope>test</scope>
+  <groupId>org.ministack</groupId>
+  <artifactId>testcontainers-ministack</artifactId>
+  <version>0.1.0</version>
+  <scope>test</scope>
 </dependency>
 ```
 
@@ -39,15 +39,15 @@ testImplementation 'org.ministack:testcontainers-ministack:0.1.0'
 ### Quick start
 
 ```java
-try (MiniStackContainer ministack = new MiniStackContainer()) {
+try(MiniStackContainer ministack = new MiniStackContainer()){
     ministack.start();
     String endpoint = ministack.getEndpoint();
 
     S3Client s3 = S3Client.builder()
             .endpointOverride(URI.create(endpoint))
-            .region(Region.US_EAST_1)
+            .region(ministack.getRegion())
             .credentialsProvider(StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create("test", "test")))
+                    AwsBasicCredentials.create(ministack.getAccessKey(), ministack.getSecretKey())))
             .forcePathStyle(true)
             .build();
 
@@ -84,12 +84,12 @@ MiniStackContainer ministack = new MiniStackContainer("1.2.5");
 
 Coming when requested. Open an issue or upvote [ministackorg/ministack](https://github.com/ministackorg/ministack/issues/250).
 
-| Language | Status |
-|----------|--------|
-| Java | **Published** on Maven Central |
-| Go | Planned |
-| Python | Planned |
-| .NET | Planned |
+| Language | Status                         |
+|----------|--------------------------------|
+| Java     | **Published** on Maven Central |
+| Go       | Planned                        |
+| Python   | Planned                        |
+| .NET     | Planned                        |
 
 ## License
 

--- a/java/src/main/java/org/ministack/testcontainers/MiniStackContainer.java
+++ b/java/src/main/java/org/ministack/testcontainers/MiniStackContainer.java
@@ -1,5 +1,7 @@
 package org.ministack.testcontainers;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
@@ -57,10 +59,16 @@ public class MiniStackContainer extends GenericContainer<MiniStackContainer> {
     /**
      * Returns the endpoint URL for connecting AWS SDK clients.
      *
-     * @return endpoint URL (e.g. "http://localhost:32789")
+     * @return endpoint URL (e.g. "http://127.0.0.1:32789")
      */
     public String getEndpoint() {
-        return String.format("http://%s:%d", getHost(), getMappedPort(PORT));
+        try {
+            final String address = getHost();
+            String ipAddress = InetAddress.getByName(address).getHostAddress();
+            return String.format("http://%s:%d", ipAddress, getMappedPort(PORT));
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException("Cannot obtain endpoint URL", e);
+        }
     }
 
     /**


### PR DESCRIPTION
I was getting a `UnknownHostException` when using this class. After some investigation and comparing it with [other implementations](https://github.com/testcontainers/testcontainers-java/blob/main/modules/localstack/src/main/java/org/testcontainers/localstack/LocalStackContainer.java#L154), I found that getting the IP from the host when generating the endpoint URL made the errors disappear.

I'm very frustrated that I don't understand why, but it works and is used in other similar solutions.

The exception:
```
software.amazon.awssdk.core.exception.SdkClientException: Received an UnknownHostException when attempting to interact with a service. See cause for the exact endpoint that is failing to resolve. If this is happening on an endpoint that previously worked, there may be a network connectivity issue or your DNS cache could be storing endpoints for too long.
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:130)
```

P.S. Also updated README examples to match previous PR.