### PR TITLE
add tests and example for real infrastructure with RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ public MiniStackContainer miniStackContainer() {
 MiniStackContainer ministack = new MiniStackContainer("1.2.5");
 ```
 
+### Real Infrastructure
+```java
+try(MiniStackContainer ministack = new MiniStackContainer()){
+    ministack.withRealInfrastructure();
+    ministack.start();
+    String endpoint = ministack.getEndpoint();
+
+    RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
+            .credentialsProvider(creds).build();
+
+    CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+            .dbInstanceIdentifier("postgres")
+            .dbInstanceClass("db.t3.micro")
+            .engine("postgres")
+            .masterUsername("admin")
+            .masterUserPassword("password")
+            .dbName("postgresdb")
+            .allocatedStorage(20)
+    );
+    
+    // Ministack will create and start a postgres docker container
+    // Before you connect to postgres you have to wait until the container is started
+}
+```
+
 ### What you get
 
 - All 41 AWS services on a single container

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,6 +182,30 @@
             <version>2.30.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>2.30.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>9.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.5.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/src/test/java/org/ministack/testcontainers/MiniStackRealInfrastructureTest.java
+++ b/java/src/test/java/org/ministack/testcontainers/MiniStackRealInfrastructureTest.java
@@ -1,0 +1,225 @@
+package org.ministack.testcontainers;
+
+import com.mysql.cj.jdbc.exceptions.CommunicationsException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PSQLException;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
+import software.amazon.awssdk.services.rds.model.Endpoint;
+
+import java.net.URI;
+import java.sql.DriverManager;
+import java.sql.SQLNonTransientConnectionException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MiniStackRealInfrastructureTest {
+
+    static MiniStackContainer ministack = new MiniStackContainer("latest");
+    static StaticCredentialsProvider creds;
+    static Region region;
+
+    @BeforeAll
+    static void startContainer() {
+        ministack.withRealInfrastructure();
+        ministack.start();
+        creds = StaticCredentialsProvider
+                .create(AwsBasicCredentials.create(ministack.getAccessKey(), ministack.getSecretKey()));
+        region = Region.of(ministack.getRegion());
+    }
+
+    @AfterAll
+    static void stopContainer() {
+        ministack.stop();
+    }
+
+    private URI endpoint() {
+        return URI.create(ministack.getEndpoint());
+    }
+
+    @Test
+    @Order(1)
+    void containerIsRunning() {
+        assertTrue(ministack.isRunning());
+        assertNotNull(ministack.getEndpoint());
+        assertTrue(ministack.getPort() > 0);
+        assertNotNull(ministack.getAccessKey());
+        assertNotNull(ministack.getSecretKey());
+        assertNotNull(ministack.getRegion());
+    }
+
+    // -----------------------------------------------------------------------
+    // RDS (real infrastructure)
+    // -----------------------------------------------------------------------
+
+
+    @Test
+    void rdsCreateDbInstancePostgres() {
+        RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
+                .credentialsProvider(creds).build();
+        String username = "admin";
+        String password = "password";
+        String dbName = "postgresdb";
+        CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+                .dbInstanceIdentifier("postgres")
+                .dbInstanceClass("db.t3.micro")
+                .engine("postgres")
+                .masterUsername(username)
+                .masterUserPassword(password)
+                .dbName(dbName)
+                .allocatedStorage(20)
+        );
+        Endpoint dbEndpoint = createDbInstanceResponse.dbInstance().endpoint();
+        assertNotNull(dbEndpoint);
+
+        String dbInstanceIdentifier = createDbInstanceResponse.dbInstance().dbInstanceIdentifier();
+
+        String jdbcUrl = String.format("jdbc:postgresql://%s:%s/%s", dbEndpoint.address(), dbEndpoint.port(), dbName);
+
+        // We have to wait here until db container ist started
+        Awaitility.given().ignoreException(PSQLException.class)
+                .await().atMost(Duration.ofSeconds(10))
+                .until(() -> DriverManager.getConnection(jdbcUrl, username, password).isValid(10));
+
+        // Manually stop and remove DB container because it is not handled by Testcontainers
+        rds.deleteDBInstance(b -> b.dbInstanceIdentifier(dbInstanceIdentifier));
+    }
+
+    @Test
+    void rdsCreateDbInstanceAuroraPostgres() {
+        RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
+                .credentialsProvider(creds).build();
+        String username = "admin";
+        String password = "password";
+        String dbName = "aurora-postgres-db";
+        CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+                .dbInstanceIdentifier("aurora-postgresql")
+                .dbInstanceClass("db.t3.micro")
+                .engine("aurora-postgresql")
+                .masterUsername(username)
+                .masterUserPassword(password)
+                .dbName(dbName)
+                .allocatedStorage(20)
+        );
+        Endpoint dbEndpoint = createDbInstanceResponse.dbInstance().endpoint();
+        assertNotNull(dbEndpoint);
+
+        String dbInstanceIdentifier = createDbInstanceResponse.dbInstance().dbInstanceIdentifier();
+
+        String jdbcUrl = String.format("jdbc:postgresql://%s:%s/%s", dbEndpoint.address(), dbEndpoint.port(), dbName);
+
+        // We have to wait here until db container ist started
+        Awaitility.given().ignoreException(PSQLException.class)
+                .await().atMost(Duration.ofSeconds(10))
+                .until(() -> DriverManager.getConnection(jdbcUrl, username, password).isValid(10));
+
+        // Manually stop and remove DB container because it is not handled by Testcontainers
+        rds.deleteDBInstance(b -> b.dbInstanceIdentifier(dbInstanceIdentifier));
+    }
+
+    @Test
+    void rdsCreateDbInstanceMysql() {
+        RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
+                .credentialsProvider(creds).build();
+        String username = "admin";
+        String password = "password";
+        String dbName = "mysqldb";
+        CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+                .dbInstanceIdentifier("mysql")
+                .dbInstanceClass("db.t3.micro")
+                .engine("mysql")
+                .masterUsername(username)
+                .masterUserPassword(password)
+                .dbName(dbName)
+                .allocatedStorage(20)
+        );
+        Endpoint dbEndpoint = createDbInstanceResponse.dbInstance().endpoint();
+        assertNotNull(dbEndpoint);
+
+        String dbInstanceIdentifier = createDbInstanceResponse.dbInstance().dbInstanceIdentifier();
+
+        String jdbcUrl = String.format("jdbc:mysql://%s:%s/%s", dbEndpoint.address(), dbEndpoint.port(), dbName);
+
+        // We have to wait here until db container ist started
+        Awaitility.given().ignoreException(CommunicationsException.class)
+                .await().atMost(Duration.ofSeconds(20))
+                .until(() -> DriverManager.getConnection(jdbcUrl, username, password).isValid(10));
+
+        // Manually stop and remove DB container because it is not handled by Testcontainers
+        rds.deleteDBInstance(b -> b.dbInstanceIdentifier(dbInstanceIdentifier));
+    }
+
+    @Test
+    void rdsCreateDbInstanceAuroraMysql() {
+        RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
+                .credentialsProvider(creds).build();
+        String username = "admin";
+        String password = "password";
+        String dbName = "aurora-mysql-db";
+        CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+                .dbInstanceIdentifier("aurora-mysql")
+                .dbInstanceClass("db.t3.micro")
+                .engine("aurora-mysql")
+                .masterUsername(username)
+                .masterUserPassword(password)
+                .dbName(dbName)
+                .allocatedStorage(20)
+        );
+        Endpoint dbEndpoint = createDbInstanceResponse.dbInstance().endpoint();
+        assertNotNull(dbEndpoint);
+
+        String dbInstanceIdentifier = createDbInstanceResponse.dbInstance().dbInstanceIdentifier();
+
+        String jdbcUrl = String.format("jdbc:mysql://%s:%s/%s", dbEndpoint.address(), dbEndpoint.port(), dbName);
+
+        // We have to wait here until db container ist started
+        Awaitility.given().ignoreException(CommunicationsException.class)
+                .await().atMost(Duration.ofSeconds(20))
+                .until(() -> DriverManager.getConnection(jdbcUrl, username, password).isValid(10));
+
+        // Manually stop and remove DB container because it is not handled by Testcontainers
+        rds.deleteDBInstance(b -> b.dbInstanceIdentifier(dbInstanceIdentifier));
+    }
+
+    @Test
+    void rdsCreateDbInstanceMariaDb() {
+        RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
+                .credentialsProvider(creds).build();
+        String username = "admin";
+        String password = "password";
+        String dbName = "mariadb";
+        CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+                .dbInstanceIdentifier("mariadb")
+                .dbInstanceClass("db.t3.micro")
+                .engine("mariadb")
+                .masterUsername(username)
+                .masterUserPassword(password)
+                .dbName(dbName)
+                .allocatedStorage(20)
+        );
+        Endpoint dbEndpoint = createDbInstanceResponse.dbInstance().endpoint();
+        assertNotNull(dbEndpoint);
+
+        String dbInstanceIdentifier = createDbInstanceResponse.dbInstance().dbInstanceIdentifier();
+
+        String jdbcUrl = String.format("jdbc:mariadb://%s:%s/%s", dbEndpoint.address(), dbEndpoint.port(), dbName);
+
+        // We have to wait here until db container ist started
+        Awaitility.given().ignoreException(SQLNonTransientConnectionException.class)
+                .await()
+                .atMost(Duration.ofSeconds(20))
+                .until(() -> DriverManager.getConnection(jdbcUrl, username, password).isValid(10));
+
+        // Manually stop and remove DB container because it is not handled by Testcontainers
+        rds.deleteDBInstance(b -> b.dbInstanceIdentifier(dbInstanceIdentifier));
+    }
+}


### PR DESCRIPTION
Hey,

really nice that you started Testcontainers for Ministack!

I added tests for the real infrastructure for RDS with different database engines. During the tests I discovered that you have to wait until the defined database container is started and at the end of the tests you need to manually cleanup the database containers. They are not handled by Testcontainers. This should be more convenient, I guess.