### PR TITLE
fix: return getHost() directly in getEndpoint(); README accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,6 @@ try(MiniStackContainer ministack = new MiniStackContainer()){
 }
 ```
 
-### Spring Boot
-
-```java
-@Bean
-@ServiceConnection
-public MiniStackContainer miniStackContainer() {
-    return new MiniStackContainer("latest");
-}
-```
-
 ### Specific version
 
 ```java
@@ -82,7 +72,7 @@ try(MiniStackContainer ministack = new MiniStackContainer()){
     RdsClient rds = RdsClient.builder().endpointOverride(endpoint()).region(region)
             .credentialsProvider(creds).build();
 
-    CreateDbInstanceResponse createDbInstanceResponse = rds.createDBInstance(b -> b
+    rds.createDBInstance(b -> b
             .dbInstanceIdentifier("postgres")
             .dbInstanceClass("db.t3.micro")
             .engine("postgres")
@@ -91,15 +81,21 @@ try(MiniStackContainer ministack = new MiniStackContainer()){
             .dbName("postgresdb")
             .allocatedStorage(20)
     );
-    
-    // Ministack will create and start a postgres docker container
-    // Before you connect to postgres you have to wait until the container is started
+
+    // MiniStack spawns a real Postgres container. Poll DescribeDBInstances
+    // until it reports `available` before opening a JDBC connection.
+    Awaitility.await()
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(() -> "available".equals(
+            rds.describeDBInstances(b -> b.dbInstanceIdentifier("postgres"))
+               .dbInstances().get(0).dbInstanceStatus()));
 }
 ```
 
 ### What you get
 
-- All 41 AWS services on a single container
+- 55+ AWS services on a single container
 - Health check waits for readiness automatically
 - `getEndpoint()` returns the mapped URL for SDK configuration
 - Works with any AWS SDK (Java, Go, Python, Node.js)

--- a/java/src/main/java/org/ministack/testcontainers/MiniStackContainer.java
+++ b/java/src/main/java/org/ministack/testcontainers/MiniStackContainer.java
@@ -3,8 +3,6 @@ package org.ministack.testcontainers;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
 import org.testcontainers.DockerClientFactory;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -85,16 +83,15 @@ public class MiniStackContainer extends GenericContainer<MiniStackContainer> {
     /**
      * Returns the endpoint URL for connecting AWS SDK clients.
      *
-     * @return endpoint URL (e.g. "http://127.0.0.1:32789")
+     * <p>Returns the Testcontainers-reported host directly without forcing
+     * DNS resolution to an IP. Rootless Podman, Colima, and reuse modes
+     * can surface non-resolvable hostnames that nonetheless route correctly
+     * through Docker — resolving them eagerly broke those setups.
+     *
+     * @return endpoint URL (e.g. "http://localhost:32789")
      */
     public String getEndpoint() {
-        try {
-            final String address = getHost();
-            String ipAddress = InetAddress.getByName(address).getHostAddress();
-            return String.format("http://%s:%d", ipAddress, getMappedPort(PORT));
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException("Cannot obtain endpoint URL", e);
-        }
+        return String.format("http://%s:%d", getHost(), getMappedPort(PORT));
     }
 
     /**


### PR DESCRIPTION
  - getEndpoint() no longer resolves getHost() to an IP via                                    
    InetAddress.getByName(). Rootless Podman, Colima, and reuse modes                          
    surface non-resolvable hostnames that route correctly through Docker;                      
    eager resolution broke those setups.                                                       
  - README: drop @ServiceConnection example (no ContainerConnectionDetailsFactory              
    shipped — it silently no-ops).                                                             
  - README: 41 → 55+ AWS services (badge + "What you get"). 
  - README: real-infrastructure example now polls DescribeDBInstances with                     
    Awaitility until status == "available" instead of trailing off mid-comment. 